### PR TITLE
eden config --push

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ No errors found
 
 $ eden config --check -p default
 No errors found
+
+# we can push profiles to DynamoDB for use by eden API
+# if eden table does not exist, eden cli will create it
+$ eden config --push -p default
+Waiting for table creation...
+Successfully pushed profile default to DynamoDB
+
+# use the same command to overwrite existing profiles
+$ eden config --push -p default
+Successfully pushed profile default to DynamoDB
+
 ```
 
 ### Execute commands

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -128,15 +128,16 @@ def command_config(args: dict):
             logger.info(f"Found {errors} errors")
 
     elif args['push']:
-        dynamodb = boto3.client('dynamodb')
+        dynamodb_client = boto3.client('dynamodb')
+        dynamodb_resource = boto3.resource('dynamodb')
         table_name = args['remote_table_name']
 
-        status = check_remote_state_table(dynamodb, table_name)
+        status = check_remote_state_table(dynamodb_client, table_name)
 
         if not status:
             return
 
-        table = boto3.resource('dynamodb').Table(table_name)
+        table = dynamodb_resource.Table(table_name)
         table.put_item(
             Item={
                 'env_name': f"_profile_{profile_name}",

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -199,7 +199,7 @@ def command_config(args: dict):
                 response = dynamodb.describe_table(TableName=table_name)
                 table_status = response['Table']['TableStatus']
 
-        table = boto3.resource('dynamodb').Table('eden')
+        table = boto3.resource('dynamodb').Table(table_name)
         table.put_item(
             Item={
                 'env_name': f"_profile_{profile_name}",

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -25,8 +25,8 @@ def read_config(path):
 
 
 def create_parser():
-    parser = argparse.ArgumentParser(description='ECS Dynamic environment manager. '
-                                                 'Clone ecs environments easily.')
+    parser = argparse.ArgumentParser(description='ECS Dynamic Environment Manager. '
+                                                 'Clone Amazon ECS environments easily.')
 
     subparsers = parser.add_subparsers()
 

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -32,8 +32,12 @@ def create_parser():
 
     parser_config = subparsers.add_parser('config', help='Configure eden')
     parser_config.set_defaults(handler=command_config)
-    parser_config.add_argument('--check', action='store_true', help='Check configuration file integrity')
-    parser_config.add_argument('--push', action='store_true', help='Push local profile to DynamoDB for use by eden API')
+    parser_config.add_argument('--check', action='store_true',
+                               help='Check configuration file integrity')
+    parser_config.add_argument('--push', action='store_true',
+                               help='Push local profile to DynamoDB for use by eden API')
+    parser_config.add_argument('--remote-table-name', type=str, required=False, default='eden',
+                               help='profile name in eden configuration file')
 
     parser_create = subparsers.add_parser('create', help='Create environment or deploy to existent')
     parser_create.set_defaults(handler=command_create)
@@ -125,88 +129,117 @@ def command_config(args: dict):
 
     elif args['push']:
         dynamodb = boto3.client('dynamodb')
+        table_name = args['remote_table_name']
 
-        table_name = "eden"
+        status = check_remote_state_table(dynamodb, table_name)
 
-        try:
-            response = dynamodb.describe_table(TableName=table_name)
-            table_status = response['Table']['TableStatus']
-        except botocore.exceptions.NoCredentialsError:
-            logger.error("AWS credentials not found!")
+        if not status:
             return
-        except Exception as e:
-            if hasattr(e, 'response') and 'Error' in e.response:
-                if e.response['Error']['Code'] != 'ResourceNotFoundException':
-                    logger.error(f"Unknown exception raised on DescribeTable API: {e.response}")
-                    return
-            else:
-                logger.error(f"Unknown exception raised on DescribeTable API: {e}")
-                return
-
-            response = dynamodb.create_table(
-                AttributeDefinitions=[
-                    {
-                        'AttributeName': 'env_name',
-                        'AttributeType': 'S'
-                    },
-                    {
-                        'AttributeName': 'last_updated',
-                        'AttributeType': 'S'
-                    }
-                ],
-                TableName=table_name,
-                KeySchema=[
-                    {
-                        'AttributeName': 'env_name',
-                        'KeyType': 'HASH'
-                    },
-                ],
-                GlobalSecondaryIndexes=[
-                    {
-                        'IndexName': 'env_name_last_updated_gsi',
-                        'KeySchema': [
-                            {
-                                'AttributeName': 'env_name',
-                                'KeyType': 'HASH',
-                            },
-                            {
-                                'AttributeName': 'last_updated',
-                                'KeyType': 'RANGE',
-                            },
-                        ],
-                        'Projection': {
-                            'ProjectionType': 'ALL',
-                        }
-                    },
-                ],
-                BillingMode='PAY_PER_REQUEST',
-            )
-
-            table_status = response['TableDescription']['TableStatus']
-
-        if table_status == 'DELETING':
-            logger.error("Table deletion is in progress, try again later")
-            return
-
-        elif table_status == 'UPDATING':
-            logger.error("Table update is in progress, try again later")
-            return
-
-        elif table_status == 'CREATING':
-            logger.info("Waiting for table creation...")
-            while table_status != 'ACTIVE':
-                time.sleep(0.1)
-                response = dynamodb.describe_table(TableName=table_name)
-                table_status = response['Table']['TableStatus']
 
         table = boto3.resource('dynamodb').Table(table_name)
         table.put_item(
             Item={
                 'env_name': f"_profile_{profile_name}",
-                'profile': json.dumps(create_envvar_dict(args, config))
+                'profile':  json.dumps(create_envvar_dict(args, config))
             }
         )
         logger.info(f"Successfully pushed profile {profile_name} to DynamoDB")
+
+
+def check_remote_state_table(dynamodb, table_name):
+    try:
+        table_status = describe_remote_state_table(dynamodb, table_name)
+    except botocore.exceptions.NoCredentialsError:
+        logger.error("AWS credentials not found!")
+        return False
+    except Exception as e:
+        if hasattr(e, 'response') and 'Error' in e.response:
+            code = e.response['Error']['Code']
+            if code == 'ResourceNotFoundException':
+                table_status = create_remote_state_table(dynamodb, table_name)
+                if table_status is None:
+                    return False
+            else:
+                logger.error(e.response['Error']['Message'])
+                return False
+
+        else:
+            logger.error(f"Unknown exception raised: {e}")
+            return False
+
+    if table_status == 'DELETING':
+        logger.error("Table deletion is in progress, try again later")
+        return False
+
+    elif table_status == 'UPDATING':
+        logger.error("Table update is in progress, try again later")
+        return False
+
+    elif table_status == 'CREATING':
+        logger.info("Waiting for table creation...")
+        while table_status != 'ACTIVE':
+            time.sleep(0.1)
+            table_status = describe_remote_state_table(dynamodb, table_name)
+
+    return True
+
+
+def describe_remote_state_table(dynamodb, table_name):
+    response = dynamodb.describe_table(TableName=table_name)
+    table_status = response['Table']['TableStatus']
+    return table_status
+
+
+def create_remote_state_table(dynamodb, table_name):
+    try:
+        response = dynamodb.create_table(
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'env_name',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'last_updated',
+                    'AttributeType': 'S'
+                }
+            ],
+            TableName=table_name,
+            KeySchema=[
+                {
+                    'AttributeName': 'env_name',
+                    'KeyType':       'HASH'
+                },
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    'IndexName':  'env_name_last_updated_gsi',
+                    'KeySchema':  [
+                        {
+                            'AttributeName': 'env_name',
+                            'KeyType':       'HASH',
+                        },
+                        {
+                            'AttributeName': 'last_updated',
+                            'KeyType':       'RANGE',
+                        },
+                    ],
+                    'Projection': {
+                        'ProjectionType': 'ALL',
+                    }
+                },
+            ],
+            BillingMode='PAY_PER_REQUEST',
+        )
+        table_status = response['TableDescription']['TableStatus']
+        return table_status
+
+    except Exception as e:
+        if hasattr(e, 'response') and 'Error' in e.response:
+            logger.error(e.response['Error']['Message'])
+            return None
+        else:
+            logger.error(f"Unknown exception raised: {e}")
+            return None
 
 
 def check_profile(config, profile):
@@ -318,7 +351,7 @@ def main(args=sys.argv):
             # validators.check_cirn(args_dict['image_uri'])
 
             event = {
-                'branch': args_dict['name'],
+                'branch':    args_dict['name'],
                 'image_uri': args_dict['image_uri'] if 'image_uri' in args_dict else None,
             }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+botocore
 aws-eden-core==0.1.0
+boto3

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
 
 setup(
     name='aws_eden_cli',
-    version='v0.1.3',
+    version='v0.1.4',
     license='MIT',
     author='Tamirlan Torgayev',
     author_email='torgayev@me.com',


### PR DESCRIPTION
Implemented `eden config --push` command for new eden API.

Allows to use multiple eden profiles on one API instance, so we only have to create eden API itself only once per AWS account.

`eden config --push` logic:
- Check specified profile
- Check if `eden` DynamoDB table exists, creates a table if it does not exist
- Pushes JSON serialized profile to DynamoDB with hash key `_profile_{profile_name}`

TODO:
- [x] implement API side - https://github.com/baikonur-oss/terraform-aws-lambda-eden-api/pull/3
