### PR TITLE
eden config remote-delete, refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,38 @@ For example, you may want to have API, administration tool and a frontend servic
 $ pip3 install aws-eden-cli 
 
 $ eden -h
-usage: eden [-h] [-p PROFILE] [-c CONFIG_PATH] [-v] {config,create,delete} ...
+usage: eden [-h] {create,delete,config} ...
 
-create similar ecs environments easily.
+ECS Dynamic Environment Manager. Clone Amazon ECS environments easily.
 
 positional arguments:
-  {config,create,delete}
-    config              configure eden
-    create              create environment or deploy to existent
-    delete              delete environment
+  {create,delete,config}
+    create              Create environment or deploy to existent
+    delete              Delete environment
+    config              Configure eden
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+Hint: you can use -h on subcommands as well:
+```
+$ eden config -h
+usage: eden config [-h] {setup,check,push,remote-remove} ...
+
+positional arguments:
+  {setup,check,push,remote-remove}
+    setup               Setup profiles for other commands
+    check               Check configuration file integrity
+    push                Push local profile to DynamoDB for use by eden API
+    remote-remove       Remove remote profile from DynamoDB
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+$ eden config push -h
+usage: eden config push [-h] [-p PROFILE] [-c CONFIG_PATH] [-v]
+                        [--remote-table-name REMOTE_TABLE_NAME]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -100,24 +123,30 @@ optional arguments:
   -c CONFIG_PATH, --config-path CONFIG_PATH
                         eden configuration file path
   -v, --verbose
+  --remote-table-name REMOTE_TABLE_NAME
+                        profile name in eden configuration file
 ```
 
 ### Configure
 ```
-$ eden config --config-bucket-key endpoints.json
-$ eden config --config-bucket-name servicename-config
-$ eden config --config-update-key api_endpoint
-$ eden config --config-name-prefix servicename-dev
-$ eden config --domain-name-prefix api
-$ eden config --dynamic-zone-id Zxxxxxxxxxxxx
-$ eden config --dynamic-zone-name dev.example.com.
-$ eden config --master-alb-arn arn:aws:elasticloadbalancing:ap-northeast-1:xxxxxxxxxxxx:loadbalancer/app/dev-alb-api-dynamic/xxxxxxxxxx
-$ eden config --name-prefix dev-dynamic
-$ eden config --reference-service-arn arn:aws:ecs:ap-northeast-1:xxxxxxxxxxxx:service/dev/dev01-api
-$ eden config --target-cluster dev
-$ eden config --target-container-name api
+# let's create a profile to work with, 
+# so we won't have to specify all the parameters every time
+
+$ eden config setup --config-bucket-key endpoints.json
+$ eden config setup --config-bucket-name servicename-config
+$ eden config setup --config-update-key api_endpoint
+$ eden config setup --config-name-prefix servicename-dev
+$ eden config setup --domain-name-prefix api
+$ eden config setup --dynamic-zone-id Zxxxxxxxxxxxx
+$ eden config setup --dynamic-zone-name dev.example.com.
+$ eden config setup --master-alb-arn arn:aws:elasticloadbalancing:ap-northeast-1:xxxxxxxxxxxx:loadbalancer/app/dev-alb-api-dynamic/xxxxxxxxxx
+$ eden config setup --name-prefix dev-dynamic
+$ eden config setup --reference-service-arn arn:aws:ecs:ap-northeast-1:xxxxxxxxxxxx:service/dev/dev01-api
+$ eden config setup --target-cluster dev
+$ eden config setup --target-container-name api
 
 # you can also edit ~/.eden/config directly
+# (you can see that commands above created a "default" profile)
 
 $ cat ~/.eden/config
 [default]
@@ -137,34 +166,38 @@ target_container_name = api
 
 # don't forget to check configuration file integrity
 
-$ eden config --check
+$ eden config check
 No errors found
 
 # you can specify multiple profiles in configuration
 # and select a profile with -p profile_name
 
-$ eden config --check -p default
+$ eden config check -p default
 No errors found
 
 # we can push profiles to DynamoDB for use by eden API
-# if eden table does not exist, eden cli will create it
-$ eden config --push -p default
+# (if eden table does not exist, aws-eden-cli will create it)
+
+$ eden config push -p default
 Waiting for table creation...
 Successfully pushed profile default to DynamoDB
 
 # use the same command to overwrite existing profiles
-$ eden config --push -p default
+# (push to existing profile will result in overwrite)
+
+$ eden config push -p default
 Successfully pushed profile default to DynamoDB table eden
 
-# use --remote-delete to remove pushed profiles
-$ eden config --remote-delete -p default
+# use remote-delete to remove remote profiles
+
+$ eden config remote-delete -p default
 Successfully removed profile default from DynamoDB table eden
 
 ```
 
 ### Execute commands
 ```
-$ eden create --name test --cirn xxxxxxxxxxxx.dkr.ecr.ap-northeast-1.amazonaws.com/servicename-api-dev:latest
+$ eden create --name test --image-uri xxxxxxxxxxxx.dkr.ecr.ap-northeast-1.amazonaws.com/servicename-api-dev:latest
 Checking if image xxxxxxxxxxxx.dkr.ecr.ap-northeast-1.amazonaws.com/servicename-api-dev:latest exists
 Image exists
 Retrieved reference service arn:aws:ecs:ap-northeast-1:xxxxxxxxxxxx:service/dev/dev01-api
@@ -197,5 +230,3 @@ Deleted target group arn:aws:elasticloadbalancing:ap-northeast-1:xxxxxxxxxxxx:ta
 Deleted all task definitions for family: dev-dynamic-test, 1 tasks deleted total
 Successfully finished deleting environment dev-dynamic-test
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ Successfully pushed profile default to DynamoDB
 
 # use the same command to overwrite existing profiles
 $ eden config --push -p default
-Successfully pushed profile default to DynamoDB
+Successfully pushed profile default to DynamoDB table eden
+
+# use --remote-delete to remove pushed profiles
+$ eden config --remote-delete -p default
+Successfully removed profile default from DynamoDB table eden
 
 ```
 

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -134,20 +134,11 @@ def command_config_push(args):
     if not status:
         return
 
-    try:
-        table.put_item(
-            Item={
-                'env_name': f"_profile_{profile_name}",
-                'profile':  json.dumps(utils.create_envvar_dict(args, config, args['profile']))
-            }
-        )
-    except Exception as e:
-        if hasattr(e, 'response') and 'Error' in e.response:
-            logger.error(e.response['Error']['Message'])
-            return
-        else:
-            logger.error(f"Unknown exception raised: {e}")
-            return
+    profile_dict = utils.create_envvar_dict(args, config, profile_name)
+
+    status = dynamodb.create_profile(table, profile_name, profile_dict)
+    if not status:
+        return
 
     logger.info(f"Successfully pushed profile {profile_name} to DynamoDB table {table_name}")
 
@@ -158,19 +149,9 @@ def command_config_remote_delete(args):
     table_name = args['remote_table_name']
     table = dynamodb_resource.Table(table_name)
 
-    try:
-        table.delete_item(
-            Key={
-                'env_name': f"_profile_{profile_name}",
-            },
-        )
-    except Exception as e:
-        if hasattr(e, 'response') and 'Error' in e.response:
-            logger.error(e.response['Error']['Message'])
-            return
-        else:
-            logger.error(f"Unknown exception raised: {e}")
-            return
+    status = dynamodb.delete_profile(table, profile_name)
+    if not status:
+        return
 
     logger.info(f"Successfully removed profile {profile_name} from DynamoDB table {table_name}")
 

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -108,7 +108,7 @@ def command_config_check(args):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, profile_name)
+    config, _ = utils.config_write_overrides(config, args)
 
     errors = 0
     for profile in config:
@@ -125,7 +125,7 @@ def command_config_push(args):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, profile_name)
+    config, _ = utils.config_write_overrides(config, args)
 
     table_name = args['remote_table_name']
     table = dynamodb_resource.Table(table_name)
@@ -182,7 +182,7 @@ def command_create(args: dict, name, image_uri):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, profile_name)
+    config, _ = utils.config_write_overrides(config, args)
 
     variables = utils.create_envvar_dict(args, config)
     function.create_env(name, image_uri, variables)
@@ -194,7 +194,7 @@ def command_delete(args: dict, name):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, profile_name)
+    config, _ = utils.config_write_overrides(config, args)
 
     variables = utils.create_envvar_dict(args, config)
     function.delete_env(name, variables)

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -104,7 +104,6 @@ def command_config_setup(args: dict):
 
 def command_config_check(args):
     setup_logging(args['verbose'])
-    profile_name = args['profile']
     config = utils.parse_config(args)
     if config is None:
         return
@@ -178,7 +177,6 @@ def command_config_remote_delete(args):
 
 def command_create(args: dict, name, image_uri):
     setup_logging(args['verbose'])
-    profile_name = args['profile']
     config = utils.parse_config(args)
     if config is None:
         return
@@ -190,7 +188,6 @@ def command_create(args: dict, name, image_uri):
 
 def command_delete(args: dict, name):
     setup_logging(args['verbose'])
-    profile_name = args['profile']
     config = utils.parse_config(args)
     if config is None:
         return

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -73,9 +73,9 @@ def create_parser():
         i.add_argument('-v', '--verbose', action='store_true')
 
     # switches for remote subcommands
-    for i in [parser_config_push, ]:
+    for i in [parser_config_push, parser_config_remote_delete]:
         i.add_argument('--remote-table-name', type=str, required=False, default='eden',
-                       help='profile name in eden configuration file')
+                       help='Remote DynamoDB table name')
 
     for i in [parser_create, parser_delete]:
         i.add_argument('--name', type=str, required=True, help='Environment name (branch name etc.)')

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -50,7 +50,7 @@ def create_parser():
     parser_config_push.set_defaults(handler=command_config_push)
 
     # eden config remote_remove
-    parser_config_remote_delete = config_subparsers.add_parser('remote_remove',
+    parser_config_remote_delete = config_subparsers.add_parser('remote-remove',
                                                                help='Remove remote profile from DynamoDB')
     parser_config_remote_delete.set_defaults(handler=command_config_remote_delete)
 

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -1,30 +1,19 @@
 import argparse
-import configparser
 import json
 import logging
 import os
 import sys
-import time
 from pathlib import Path
 
-import boto3
-import botocore
-from botocore.exceptions import ClientError
-
-from . import consts
 import aws_eden_core.methods as function
+import boto3
+
+from . import consts, utils, dynamodb
 
 dynamodb_client = boto3.client('dynamodb')
 dynamodb_resource = boto3.resource('dynamodb')
 
-parameters = consts.parameters
 logger = logging.getLogger()
-
-
-def read_config(path):
-    config = configparser.ConfigParser()
-    config.read(path)
-    return config
 
 
 def create_parser():
@@ -33,28 +22,48 @@ def create_parser():
 
     subparsers = parser.add_subparsers()
 
-    parser_config = subparsers.add_parser('config', help='Configure eden')
-    parser_config.set_defaults(handler=command_config)
-    parser_config.add_argument('--check', action='store_true',
-                               help='Check configuration file integrity')
-    parser_config.add_argument('--push', action='store_true',
-                               help='Push local profile to DynamoDB for use by eden API')
-    parser_config.add_argument('--remote-delete', action='store_true',
-                               help='Remove remote profile from DynamoDB')
-    parser_config.add_argument('--remote-table-name', type=str, required=False, default='eden',
-                               help='profile name in eden configuration file')
-
+    # eden create
     parser_create = subparsers.add_parser('create', help='Create environment or deploy to existent')
     parser_create.set_defaults(handler=command_create)
 
+    # eden delete
     parser_delete = subparsers.add_parser('delete', help='Delete environment')
     parser_delete.set_defaults(handler=command_delete)
 
-    for i in [parser_config, parser_create, parser_delete]:
-        for p in parameters:
+    # eden config *
+    parser_config = subparsers.add_parser('config', help='Configure eden')
+
+    # eden config setup
+    config_subparsers = parser_config.add_subparsers()
+    parser_config_setup = config_subparsers.add_parser('setup',
+                                                       help='Setup profiles for other commands')
+    parser_config_setup.set_defaults(handler=command_config_setup)
+
+    # eden config check
+    parser_config_check = config_subparsers.add_parser('check',
+                                                       help='Check configuration file integrity')
+    parser_config_check.set_defaults(handler=command_config_check)
+
+    # eden config push
+    parser_config_push = config_subparsers.add_parser('push',
+                                                      help='Push local profile to DynamoDB for use by eden API')
+    parser_config_push.set_defaults(handler=command_config_push)
+
+    # eden config remote_remove
+    parser_config_remote_delete = config_subparsers.add_parser('remote_remove',
+                                                               help='Remove remote profile from DynamoDB')
+    parser_config_remote_delete.set_defaults(handler=command_config_remote_delete)
+
+    # profile vars for no profile or profile override
+    for i in [parser_config_setup, parser_create, parser_delete]:
+        for p in consts.parameters:
             i.add_argument(p['flag'], type=str, required=False,
                            help=p['help_string'])
 
+    # switches for all subcommands
+    for i in [parser_config_setup, parser_config_check,  # local profile config commands
+              parser_config_push, parser_config_remote_delete,  # remote commands
+              parser_create, parser_delete]:
         i.add_argument('-p', '--profile', type=str, required=False, default='default',
                        help='profile name in eden configuration file')
 
@@ -62,6 +71,11 @@ def create_parser():
                        help='eden configuration file path')
 
         i.add_argument('-v', '--verbose', action='store_true')
+
+    # switches for remote subcommands
+    for i in [parser_config_push, ]:
+        i.add_argument('--remote-table-name', type=str, required=False, default='eden',
+                       help='profile name in eden configuration file')
 
     for i in [parser_create, parser_delete]:
         i.add_argument('--name', type=str, required=True, help='Environment name (branch name etc.)')
@@ -72,77 +86,51 @@ def create_parser():
     return parser
 
 
-def command_config(args: dict):
-    table_name = args['remote_table_name']
-    table = dynamodb_resource.Table(table_name)
-
-    default_config_path = os.path.expanduser('~/.eden')
-    if not os.path.exists(default_config_path):
-        os.makedirs(default_config_path)
-
-    config_file_path = os.path.expanduser(args['config_path'])
-    config_file = Path(config_file_path)
-    if not config_file.is_file():
-        logger.info(f"Config file {path} is empty")
+def command_config_setup(args: dict):
+    setup_logging(args['verbose'])
+    config = utils.parse_config(args)
+    if config is None:
         return
-
-    config = read_config(path)
-
-    updated = False
-
-    profile_name = args['profile']
-
-    if profile_name not in config:
-        config[profile_name] = {}
-
-    for parameter in parameters:
-        key = parameter['name']
-
-        if key not in args:
-            continue
-        value = args[key]
-
-        if value is None:
-            continue
-
-        logger.info(f"Setting {key} to {value} in profile {profile_name}")
-        config[profile_name][key] = value
-        updated = True
+    config, updated = utils.config_write_overrides(config, args)
 
     if updated:
-        with open(path, 'w') as configfile:
+        config_file_path = os.path.expanduser(args['config_path'])
+        config_file = Path(config_file_path)
+        with open(config_file, 'w') as configfile:
             config.write(configfile)
     else:
-        if not args['check'] and not args['push'] and not args['remote_delete']:
-            logger.error("No parameters to update were given, exiting")
-            return
-
-    if args['check']:
-        command_config_check(config)
-
-    elif args['push']:
-        command_config_push(args, config)
-
-    elif args['remote_delete']:
-        command_config_remote_delete(args)
+        logger.error("No parameters to update were given, exiting")
 
 
-def command_config_check(config):
+def command_config_check(args):
+    setup_logging(args['verbose'])
+    profile_name = args['profile']
+    config = utils.parse_config(args)
+    if config is None:
+        return
+    config, _ = utils.config_write_overrides(config, profile_name)
+
     errors = 0
     for profile in config:
-        errors += check_profile(config, profile)
+        errors += utils.check_profile(config, profile)
     if errors == 0:
         logger.info("No errors found")
     else:
         logger.info(f"Found {errors} errors")
 
 
-def command_config_push(args, config):
+def command_config_push(args):
+    setup_logging(args['verbose'])
     profile_name = args['profile']
+    config = utils.parse_config(args)
+    if config is None:
+        return
+    config, _ = utils.config_write_overrides(config, profile_name)
+
     table_name = args['remote_table_name']
     table = dynamodb_resource.Table(table_name)
 
-    status = check_remote_state_table(dynamodb_client, table_name)
+    status = dynamodb.check_remote_state_table(dynamodb_client, table_name)
 
     if not status:
         return
@@ -151,7 +139,7 @@ def command_config_push(args, config):
         table.put_item(
             Item={
                 'env_name': f"_profile_{profile_name}",
-                'profile':  json.dumps(create_envvar_dict(args, config))
+                'profile':  json.dumps(utils.create_envvar_dict(args, config))
             }
         )
     except Exception as e:
@@ -166,6 +154,7 @@ def command_config_push(args, config):
 
 
 def command_config_remote_delete(args):
+    setup_logging(args['verbose'])
     profile_name = args['profile']
     table_name = args['remote_table_name']
     table = dynamodb_resource.Table(table_name)
@@ -187,177 +176,28 @@ def command_config_remote_delete(args):
     logger.info(f"Successfully removed profile {profile_name} from DynamoDB table {table_name}")
 
 
-def check_remote_state_table(dynamodb, table_name):
-    try:
-        table_status = describe_remote_state_table(dynamodb, table_name)
-    except botocore.exceptions.NoCredentialsError:
-        logger.error("AWS credentials not found!")
-        return False
-    except Exception as e:
-        if hasattr(e, 'response') and 'Error' in e.response:
-            code = e.response['Error']['Code']
-            if code == 'ResourceNotFoundException':
-                table_status = create_remote_state_table(dynamodb, table_name)
-                if table_status is None:
-                    return False
-            else:
-                logger.error(e.response['Error']['Message'])
-                return False
-
-        else:
-            logger.error(f"Unknown exception raised: {e}")
-            return False
-
-    if table_status == 'DELETING':
-        logger.error("Table deletion is in progress, try again later")
-        return False
-
-    elif table_status == 'UPDATING':
-        logger.error("Table update is in progress, try again later")
-        return False
-
-    elif table_status == 'CREATING':
-        logger.info("Waiting for table creation...")
-        while table_status != 'ACTIVE':
-            time.sleep(0.1)
-            table_status = describe_remote_state_table(dynamodb, table_name)
-
-    return True
-
-
-def describe_remote_state_table(dynamodb, table_name):
-    response = dynamodb.describe_table(TableName=table_name)
-    table_status = response['Table']['TableStatus']
-    return table_status
-
-
-def create_remote_state_table(dynamodb, table_name):
-    try:
-        response = dynamodb.create_table(
-            AttributeDefinitions=[
-                {
-                    'AttributeName': 'env_name',
-                    'AttributeType': 'S'
-                },
-                {
-                    'AttributeName': 'last_updated',
-                    'AttributeType': 'S'
-                }
-            ],
-            TableName=table_name,
-            KeySchema=[
-                {
-                    'AttributeName': 'env_name',
-                    'KeyType':       'HASH'
-                },
-            ],
-            GlobalSecondaryIndexes=[
-                {
-                    'IndexName':  'env_name_last_updated_gsi',
-                    'KeySchema':  [
-                        {
-                            'AttributeName': 'env_name',
-                            'KeyType':       'HASH',
-                        },
-                        {
-                            'AttributeName': 'last_updated',
-                            'KeyType':       'RANGE',
-                        },
-                    ],
-                    'Projection': {
-                        'ProjectionType': 'ALL',
-                    }
-                },
-            ],
-            BillingMode='PAY_PER_REQUEST',
-        )
-        table_status = response['TableDescription']['TableStatus']
-        return table_status
-
-    except Exception as e:
-        if hasattr(e, 'response') and 'Error' in e.response:
-            logger.error(e.response['Error']['Message'])
-            return None
-        else:
-            logger.error(f"Unknown exception raised: {e}")
-            return None
-
-
-def check_profile(config, profile):
-    errors = 0
-    if profile == "DEFAULT":
-        logger.debug("Skipping ConfigParser DEFAULT profile (comes up even if not in file)")
-        return 0
-
-    if profile not in config:
-        logger.error(f"Profile {profile} is not in config file")
-        errors += 1
-        return errors
-
-    for parameter in parameters:
-        key = parameter['name']
-
-        if key not in config[profile]:
-            logger.error(f"Necessary key {key} is not provided for profile {profile}")
-            errors += 1
-            continue
-        value = config[profile][key]
-
-        if value is None:
-            logger.error(f"Necessary key {key} is None for profile {profile}")
-            errors += 1
-            continue
-
-        if not parameter['validator'](value):
-            logger.error(f"Validation failed for key {key} in profile {profile}")
-            errors += 1
-            continue
-    return errors
-
-
-def command_create(args: dict, event: dict):
-    path = os.path.expanduser('~/.eden')
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-    path = os.path.expanduser(args['config_path'])
-    config = read_config(path)
-
-    variables = create_envvar_dict(args, config)
-    function.create_env(event['branch'], event['image_uri'], variables)
-
-
-def command_delete(args: dict, event: dict):
-    path = os.path.expanduser('~/.eden')
-    if not os.path.exists(path):
-        os.makedirs(path)
-
-    path = os.path.expanduser(args['config_path'])
-    config = read_config(path)
-
-    variables = create_envvar_dict(args, config)
-    function.delete_env(event['branch'], variables)
-
-
-def create_envvar_dict(args, config):
-    variables = {}
+def command_create(args: dict, name, image_uri):
+    setup_logging(args['verbose'])
     profile_name = args['profile']
+    config = utils.parse_config(args)
+    if config is None:
+        return
+    config, _ = utils.config_write_overrides(config, profile_name)
 
-    for p in parameters:
-        parameter_name = p['name']
+    variables = utils.create_envvar_dict(args, config)
+    function.create_env(name, image_uri, variables)
 
-        if parameter_name in args:
-            if args[parameter_name] is not None:
-                variables[p['envvar_name']] = args[parameter_name]
-                continue
-        if profile_name not in config or parameter_name not in config[profile_name]:
-            logger.error(f"Necessary parameter {parameter_name} not found in profile {profile_name} "
-                         f"and is not provided as an argument")
-            exit(-1)
-        else:
-            variables[p['envvar_name']] = config[profile_name][parameter_name]
 
-    return variables
+def command_delete(args: dict, name):
+    setup_logging(args['verbose'])
+    profile_name = args['profile']
+    config = utils.parse_config(args)
+    if config is None:
+        return
+    config, _ = utils.config_write_overrides(config, profile_name)
+
+    variables = utils.create_envvar_dict(args, config)
+    function.delete_env(name, variables)
 
 
 def setup_logging(debug):
@@ -385,18 +225,11 @@ def main(args=sys.argv):
     args = parser.parse_args(args=args)
     args_dict = vars(args)
 
-    setup_logging(args_dict['verbose'])
-
     if hasattr(args, 'handler'):
-        if args.handler != command_config:
-            # validators.check_cirn(args_dict['image_uri'])
-
-            event = {
-                'branch':    args_dict['name'],
-                'image_uri': args_dict['image_uri'] if 'image_uri' in args_dict else None,
-            }
-
-            args.handler(args_dict, event)
+        if args.handler == command_create:
+            args.handler(args_dict, args.name, args.image_uri)
+        elif args.handler == command_delete:
+            args.handler(args_dict, args.name)
         else:
             args.handler(args_dict)
     else:

--- a/aws_eden_cli/cmdline.py
+++ b/aws_eden_cli/cmdline.py
@@ -91,7 +91,7 @@ def command_config_setup(args: dict):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, updated = utils.config_write_overrides(config, args)
+    config, updated = utils.config_write_overrides(args, config, args['profile'])
 
     if updated:
         config_file_path = os.path.expanduser(args['config_path'])
@@ -107,7 +107,7 @@ def command_config_check(args):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, args)
+    config, _ = utils.config_write_overrides(args, config, args['profile'])
 
     errors = 0
     for profile in config:
@@ -124,7 +124,7 @@ def command_config_push(args):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, args)
+    config, _ = utils.config_write_overrides(args, config, args['profile'])
 
     table_name = args['remote_table_name']
     table = dynamodb_resource.Table(table_name)
@@ -138,7 +138,7 @@ def command_config_push(args):
         table.put_item(
             Item={
                 'env_name': f"_profile_{profile_name}",
-                'profile':  json.dumps(utils.create_envvar_dict(args, config))
+                'profile':  json.dumps(utils.create_envvar_dict(args, config, args['profile']))
             }
         )
     except Exception as e:
@@ -180,9 +180,9 @@ def command_create(args: dict, name, image_uri):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, args)
+    config, _ = utils.config_write_overrides(args, config, args['profile'])
 
-    variables = utils.create_envvar_dict(args, config)
+    variables = utils.create_envvar_dict(args, config, args['profile'])
     function.create_env(name, image_uri, variables)
 
 
@@ -191,9 +191,9 @@ def command_delete(args: dict, name):
     config = utils.parse_config(args)
     if config is None:
         return
-    config, _ = utils.config_write_overrides(config, args)
+    config, _ = utils.config_write_overrides(args, config, args['profile'])
 
-    variables = utils.create_envvar_dict(args, config)
+    variables = utils.create_envvar_dict(args, config, args['profile'])
     function.delete_env(name, variables)
 
 

--- a/aws_eden_cli/dynamodb.py
+++ b/aws_eden_cli/dynamodb.py
@@ -100,3 +100,38 @@ def check_remote_state_table(dynamodb, table_name):
             table_status = describe_remote_state_table(dynamodb, table_name)
 
     return True
+
+
+def delete_profile(table, profile_name):
+    try:
+        table.delete_item(
+            Key={
+                'env_name': f"_profile_{profile_name}",
+            },
+        )
+    except Exception as e:
+        if hasattr(e, 'response') and 'Error' in e.response:
+            logger.error(e.response['Error']['Message'])
+            return False
+        else:
+            logger.error(f"Unknown exception raised: {e}")
+            return False
+    return True
+
+
+def create_profile(table, profile_name, profile_dict):
+    try:
+        table.put_item(
+            Item={
+                'env_name': f"_profile_{profile_name}",
+                'profile':  json.dumps(profile_dict)
+            }
+        )
+    except Exception as e:
+        if hasattr(e, 'response') and 'Error' in e.response:
+            logger.error(e.response['Error']['Message'])
+            return False
+        else:
+            logger.error(f"Unknown exception raised: {e}")
+            return False
+    return True

--- a/aws_eden_cli/dynamodb.py
+++ b/aws_eden_cli/dynamodb.py
@@ -1,0 +1,102 @@
+import logging
+import time
+
+import botocore
+
+logger = logging.getLogger()
+
+
+def describe_remote_state_table(dynamodb, table_name):
+    response = dynamodb.describe_table(TableName=table_name)
+    table_status = response['Table']['TableStatus']
+    return table_status
+
+
+def create_remote_state_table(dynamodb, table_name):
+    try:
+        response = dynamodb.create_table(
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'env_name',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'last_updated',
+                    'AttributeType': 'S'
+                }
+            ],
+            TableName=table_name,
+            KeySchema=[
+                {
+                    'AttributeName': 'env_name',
+                    'KeyType':       'HASH'
+                },
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    'IndexName':  'env_name_last_updated_gsi',
+                    'KeySchema':  [
+                        {
+                            'AttributeName': 'env_name',
+                            'KeyType':       'HASH',
+                        },
+                        {
+                            'AttributeName': 'last_updated',
+                            'KeyType':       'RANGE',
+                        },
+                    ],
+                    'Projection': {
+                        'ProjectionType': 'ALL',
+                    }
+                },
+            ],
+            BillingMode='PAY_PER_REQUEST',
+        )
+        table_status = response['TableDescription']['TableStatus']
+        return table_status
+
+    except Exception as e:
+        if hasattr(e, 'response') and 'Error' in e.response:
+            logger.error(e.response['Error']['Message'])
+            return None
+        else:
+            logger.error(f"Unknown exception raised: {e}")
+            return None
+
+
+def check_remote_state_table(dynamodb, table_name):
+    try:
+        table_status = describe_remote_state_table(dynamodb, table_name)
+    except botocore.exceptions.NoCredentialsError:
+        logger.error("AWS credentials not found!")
+        return False
+    except Exception as e:
+        if hasattr(e, 'response') and 'Error' in e.response:
+            code = e.response['Error']['Code']
+            if code == 'ResourceNotFoundException':
+                table_status = create_remote_state_table(dynamodb, table_name)
+                if table_status is None:
+                    return False
+            else:
+                logger.error(e.response['Error']['Message'])
+                return False
+
+        else:
+            logger.error(f"Unknown exception raised: {e}")
+            return False
+
+    if table_status == 'DELETING':
+        logger.error("Table deletion is in progress, try again later")
+        return False
+
+    elif table_status == 'UPDATING':
+        logger.error("Table update is in progress, try again later")
+        return False
+
+    elif table_status == 'CREATING':
+        logger.info("Waiting for table creation...")
+        while table_status != 'ACTIVE':
+            time.sleep(0.1)
+            table_status = describe_remote_state_table(dynamodb, table_name)
+
+    return True

--- a/aws_eden_cli/utils.py
+++ b/aws_eden_cli/utils.py
@@ -90,8 +90,8 @@ def create_envvar_dict(args, config):
     profile_name = args['profile']
 
     for parameter in consts.parameters:
-        parameter_name = p['name']
-        envvar_name = p['envvar_name']
+        parameter_name = parameter['name']
+        envvar_name = parameter['envvar_name']
 
         if parameter_name in args:
             if args[parameter_name] is not None:

--- a/aws_eden_cli/utils.py
+++ b/aws_eden_cli/utils.py
@@ -28,10 +28,8 @@ def parse_config(args):
     return read_config(config_file)
 
 
-def config_write_overrides(config, args):
+def config_write_overrides(args, config, profile_name):
     updated = False
-
-    profile_name = args['profile']
 
     if profile_name not in config:
         config[profile_name] = {}
@@ -85,9 +83,8 @@ def check_profile(config, profile):
     return errors
 
 
-def create_envvar_dict(args, config):
+def create_envvar_dict(args, config, profile_name):
     variables = {}
-    profile_name = args['profile']
 
     for parameter in consts.parameters:
         parameter_name = parameter['name']

--- a/aws_eden_cli/utils.py
+++ b/aws_eden_cli/utils.py
@@ -1,0 +1,107 @@
+import configparser
+import logging
+import os
+from pathlib import Path
+
+from . import consts
+
+logger = logging.getLogger()
+
+
+def read_config(path):
+    config = configparser.ConfigParser()
+    config.read(path)
+    return config
+
+
+def parse_config(args):
+    default_config_path = os.path.expanduser('~/.eden')
+    if not os.path.exists(default_config_path):
+        os.makedirs(default_config_path)
+
+    config_file_path = os.path.expanduser(args['config_path'])
+    config_file = Path(config_file_path)
+    if not config_file.is_file():
+        logger.info(f"Config file {config_file} is empty")
+        return None
+
+    return read_config(config_file)
+
+
+def config_write_overrides(config, args):
+    updated = False
+
+    profile_name = args['profile']
+
+    if profile_name not in config:
+        config[profile_name] = {}
+
+    for parameter in consts.parameters:
+        key = parameter['name']
+
+        if key not in args:
+            continue
+        value = args[key]
+
+        if value is None:
+            continue
+
+        logger.info(f"Setting {key} to {value} in profile {profile_name}")
+        config[profile_name][key] = value
+        updated = True
+
+    return config, updated
+
+
+def check_profile(config, profile):
+    errors = 0
+    if profile == "DEFAULT":
+        logger.debug("Skipping ConfigParser DEFAULT profile (comes up even if not in file)")
+        return 0
+
+    if profile not in config:
+        logger.error(f"Profile {profile} is not in config file")
+        errors += 1
+        return errors
+
+    for parameter in consts.parameters:
+        key = parameter['name']
+
+        if key not in config[profile]:
+            logger.error(f"Necessary key {key} is not provided for profile {profile}")
+            errors += 1
+            continue
+        value = config[profile][key]
+
+        if value is None:
+            logger.error(f"Necessary key {key} is None for profile {profile}")
+            errors += 1
+            continue
+
+        if not parameter['validator'](value):
+            logger.error(f"Validation failed for key {key} in profile {profile}")
+            errors += 1
+            continue
+    return errors
+
+
+def create_envvar_dict(args, config):
+    variables = {}
+    profile_name = args['profile']
+
+    for p in consts.parameters:
+        parameter_name = p['name']
+        envvar_name = p['envvar_name']
+
+        if parameter_name in args:
+            if args[parameter_name] is not None:
+                variables[envvar_name] = args[parameter_name]
+                continue
+        if profile_name not in config or parameter_name not in config[profile_name]:
+            logger.error(f"Necessary parameter {parameter_name} not found in profile {profile_name} "
+                         f"and is not provided as an argument")
+            exit(-1)
+        else:
+            variables[envvar_name] = config[profile_name][parameter_name]
+
+    return variables

--- a/aws_eden_cli/utils.py
+++ b/aws_eden_cli/utils.py
@@ -89,7 +89,7 @@ def create_envvar_dict(args, config):
     variables = {}
     profile_name = args['profile']
 
-    for p in consts.parameters:
+    for parameter in consts.parameters:
         parameter_name = p['name']
         envvar_name = p['envvar_name']
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
 
 setup(
     name='aws_eden_cli',
-    version='v0.1.4',
+    version='v0.1.5',
     license='MIT',
     author='Tamirlan Torgayev',
     author_email='torgayev@me.com',


### PR DESCRIPTION
1. Implemented `eden config remote-delete` command for removal of remote profiles.
2. `cmdline.py` now only has main, parser builder and parser handlers. Most of other methods go to `utils.py`
3. config file parsing refactored into methods
4. Restructure parser: config command now has it's own subparsers for easier command addition (more to be added soon). 

TODO:
- [x] fix README